### PR TITLE
Fix: 포지션별 팀 선수 조회 기능 오류 수정

### DIFF
--- a/src/main/java/dao/PositionDao.java
+++ b/src/main/java/dao/PositionDao.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,43 +16,38 @@ import lombok.RequiredArgsConstructor;
 public class PositionDao {
 
 	private final Connection connection;
-	public List<PositionRespDto> getPositionInfo() {
+
+	public List<PositionRespDto> getPositionInfo() throws SQLException {
 		List<PositionRespDto> positionList = new ArrayList<>();
 
-		String query = "SET @sql = NULL; "
-			+ "SELECT GROUP_CONCAT(DISTINCT "
-			+ "           CONCAT("
-			+ "             'GROUP_CONCAT(CASE WHEN t.name = ''', "
-			+ "             t.name, "
-			+ "             ''' THEN p.name ELSE NULL END) AS `', "
-			+ "             t.name, "
-			+ "             '`' "
-			+ "           ) SEPARATOR ',') INTO @sql "
-			+ "FROM player p "
-			+ "JOIN team t ON p.team_id = t.id; "
-			+ "SET @sql = CONCAT('SELECT p.position, ', @sql, ' FROM player p JOIN team t ON p.team_id = t.id GROUP BY p.position'); "
-			+ "PREPARE stmt FROM @sql; "
-			+ "EXECUTE stmt; "
-			+ "DEALLOCATE PREPARE stmt";
+		String query1 =
+			"SELECT GROUP_CONCAT(DISTINCT CONCAT('GROUP_CONCAT(CASE WHEN t.name = ''', t.name, ''' THEN p.name ELSE NULL END) AS `', t.name, '`') SEPARATOR ',') "
+				+
+				"FROM player p JOIN team t ON p.team_id = t.id";
 
-		try (PreparedStatement statement = connection.prepareStatement(query)) {
-			boolean hasResultSet = statement.execute();
-			if (hasResultSet) {
-				try (ResultSet resultSet = statement.getResultSet()) {
-					while (resultSet.next()) {
-						String teamPlayers = resultSet.getString(2);
-						List<String> teamPlayerList = Arrays.asList(teamPlayers.split(","));
-						PositionRespDto positionDto = PositionRespDto.builder()
-							.position(Position.findByName(resultSet.getString("position")))
-							.teamPlayers(teamPlayerList)
-							.build();
-						positionList.add(positionDto);
-					}
+		try (PreparedStatement statement1 = connection.prepareStatement(
+			query1); ResultSet resultSet1 = statement1.executeQuery()) {
+			resultSet1.next();
+
+			String teams = resultSet1.getString(1);
+
+			String query2 = "SELECT p.position," + teams +
+				"FROM player p JOIN team t ON p.team_id = t.id " +
+				"GROUP BY p.position";
+
+			try (PreparedStatement statement2 = connection.prepareStatement(
+				query2); ResultSet resultSet2 = statement2.executeQuery()) {
+				while (resultSet2.next()) {
+					String teamPlayers = resultSet2.getString(2);
+					List<String> teamPlayerList = Arrays.asList(teamPlayers.split(","));
+					PositionRespDto positionDto = PositionRespDto.builder()
+						.position(Position.findByName(resultSet2.getString("position")))
+						.teamPlayers(teamPlayerList)
+						.build();
+					positionList.add(positionDto);
 				}
 			}
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
+			return positionList;
 		}
-		return positionList;
 	}
 }


### PR DESCRIPTION
- executeQuery() 메서드는 단순 조회 제공 (mysql prepare, execute 등 명령 실행 안됨)
- SELECT GROUP_CONCAT(DISTINCT CONCAT('GROUP_CONCAT(CASE WHEN t.name = ''', t.name, ''' THEN p.name ELSE NULL END) AS `', t.name, '`') SEPARATOR ',') FROM player p JOIN team t ON p.team_id = t.id;
  해당 쿼리 먼저 실행하여 동적 컬럼 생성
- SELECT p.position, value FROM player p JOIN team t ON p.team_id = t.id GROUP BY p.position 위에서 생성한 컬럼을 해당 쿼리 value부분에 대입하여 최종 쿼리 작성