### PR TITLE
Fix: 목록조회 안되는 오류 수정

### DIFF
--- a/src/main/java/util/ComponentScan.java
+++ b/src/main/java/util/ComponentScan.java
@@ -63,8 +63,9 @@ public class ComponentScan {
 
 						try {
 							if (method.getParameterTypes().length == 0) {
-								method.invoke(instance);
-								break;
+								String response = (String)method.invoke(instance);
+
+								return response;
 							}
 
 							Class<?>[] parameterTypes = method.getParameterTypes();


### PR DESCRIPTION
- 리플렉션에서 메서드에 파라미터가 없을 때 분기를 했는데 해당 분기에서 void 타입으로 실행만하고 있어서 String 타입으로 결과값 return 하도록 수정